### PR TITLE
Enable web applications to request iCal file of shared calendar.

### DIFF
--- a/controller/exportcontroller.php
+++ b/controller/exportcontroller.php
@@ -54,7 +54,7 @@ class ExportController extends Controller {
 	/**
 	*@PublicPage
 	 * @NoCSRFRequired
-	 * 
+	 * @CORS
 	 */
 	public function exportEvents(){
 		$token = $this -> params('t');	


### PR DESCRIPTION
To test this PR, please take a look at this Gist: https://gist.github.com/mattsches/60bf353561858bf9be9d

I contains an HTML file that can be used to test the difference between adding and not adding the @CORS annotation and contains further explanation. Refers to https://github.com/libasys/calendarplus/issues/171

This applies to Calendar+ versions 1.1.x and OwnCloud versions 8.1.x. It does not work with OwnCloud 8.2.x because the _share a calendar_ functionality seems to be broken there.
